### PR TITLE
fix(bridge-core): remove quotes from systemd working directory

### DIFF
--- a/packages/bridge-core/src/service.test.ts
+++ b/packages/bridge-core/src/service.test.ts
@@ -55,6 +55,8 @@ describe('service helpers', () => {
     expect(unit).toContain('Description=Clawket Bridge CLI');
     expect(unit).toContain('ExecStart="/home/tester/.clawket/clawket-launcher.sh"');
     expect(unit).toContain('Restart=always');
+    expect(unit).toContain('WorkingDirectory=');
+    expect(unit).not.toContain('WorkingDirectory="');
     expect(unit).toContain('StandardOutput=append:/home/tester/.clawket/logs/bridge-cli.log');
   });
 

--- a/packages/bridge-core/src/service.ts
+++ b/packages/bridge-core/src/service.ts
@@ -429,7 +429,7 @@ Type=simple
 ExecStart=${execStart}
 Restart=always
 RestartSec=2
-WorkingDirectory=${escapeSystemdArg(SERVICE_DIR)}
+WorkingDirectory=${SERVICE_DIR}
 StandardOutput=append:${logPath}
 StandardError=append:${errorLogPath}
 


### PR DESCRIPTION
Fix the generated Linux systemd service file to avoid wrapping `WorkingDirectory` in extra double quotes.

This fixes the service path formatting so the working directory can be recognized correctly when the service is installed.
