### PR TITLE
fix(bridge): forward image attachments to Hermes /v1/runs

### DIFF
--- a/packages/bridge-runtime/src/hermes.ts
+++ b/packages/bridge-runtime/src/hermes.ts
@@ -1223,6 +1223,17 @@ export class HermesLocalBridge {
       return this.handleFastCommand(sessionKey, text, idempotencyKey || undefined);
     }
 
+    // Build multimodal input when image attachments are present.
+    // The Hermes /v1/runs endpoint accepts OpenAI-style content arrays
+    // with image_url parts (data: URLs or http(s) URLs).
+    const attachments = Array.isArray(payload.attachments) ? payload.attachments : [];
+    const imageAttachments = attachments.filter(
+      (att: Record<string, unknown>) =>
+        typeof att === 'object' && att !== null &&
+        typeof att.mimeType === 'string' && att.mimeType.startsWith('image/') &&
+        typeof att.content === 'string' && att.content.length > 0,
+    );
+
     const session = this.sessionStore.ensureSession(sessionKey);
     this.sessionStore.appendMessage(sessionKey, {
       role: 'user',
@@ -1232,11 +1243,28 @@ export class HermesLocalBridge {
     });
     this.updateSnapshot({ sessionCount: this.sessionStore.count() });
 
+    // When images are present, send input as a content-parts array so the
+    // Hermes API server treats it as multimodal.  Otherwise keep the plain
+    // string for backward compatibility and smaller payloads.
+    let input: string | Array<Record<string, unknown>>;
+    if (imageAttachments.length > 0) {
+      const parts: Array<Record<string, unknown>> = [{ type: 'text', text }];
+      for (const att of imageAttachments) {
+        parts.push({
+          type: 'image_url',
+          image_url: { url: `data:${att.mimeType};base64,${att.content}` },
+        });
+      }
+      input = parts;
+    } else {
+      input = text;
+    }
+
     const startResponse = await fetch(`${this.apiBaseUrl}/v1/runs`, {
       method: 'POST',
       headers: buildHermesApiHeaders(this.apiKey),
       body: JSON.stringify({
-        input: text,
+        input,
         conversation_history: session.messages.map((message) => ({
           role: message.role,
           content: message.content,


### PR DESCRIPTION
## Problem

`handleChatSend()` in `packages/bridge-runtime/src/hermes.ts` silently drops the `attachments` array from `chat.send` payloads. The mobile app already prepares images as base64 attachments (see `useChatController.ts:1620`), and the Hermes API server natively supports OpenAI-style `image_url` content parts — the bridge was the missing link.

## Root Cause

Line 1239 (old): `input: text` — only the text string is sent to `/v1/runs`, attachments are completely ignored.

## Fix

When image attachments are present, convert them to OpenAI multimodal content format and send as the `input` field:

```typescript
// Before (attachments dropped):
input: text

// After (attachments forwarded):
input: [
  { type: 'text', text: 'Look at this image' },
  { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,...' } }
]
```

When no attachments are present, the plain string format is preserved for backward compatibility and smaller payloads.

## How it works

1. Mobile app sends `chat.send` with `attachments: [{ type: 'image', mimeType: 'image/jpeg', content: '<base64>' }]`
2. Bridge converts to OpenAI format: `[{ type: 'image_url', image_url: { url: 'data:image/jpeg;base64,...' } }]`
3. Sends as `input` array to Hermes `/v1/runs`
4. Hermes API server's `_normalize_multimodal_content()` (api_server.py:178) handles the rest — it already accepts `image_url` and `input_image` parts with data: URLs

## Files changed

- `packages/bridge-runtime/src/hermes.ts` — 29 lines added, 1 changed

## No Hermes changes needed

The Hermes API server already has full multimodal support. No modifications to Hermes source are required.